### PR TITLE
Closes #1

### DIFF
--- a/pyan/analyzer.py
+++ b/pyan/analyzer.py
@@ -699,7 +699,7 @@ class CallGraphVisitor(ast.NodeVisitor):
         or None if not applicable; and flavor is a Flavor, specifically one of
         FUNCTION, METHOD, STATICMETHOD or CLASSMETHOD."""
 
-        if not isinstance(ast_node, ast.FunctionDef):
+        if not (isinstance(ast_node, ast.FunctionDef) or isinstance(ast_node, ast.AsyncFunctionDef)):
             raise TypeError("Expected ast.FunctionDef; got %s" % (type(ast_node)))
 
         # Visit decorators


### PR DESCRIPTION
The upstream version isn't able to deal with `async def` at all. This PR is still not ideal (since one might want to be able to differentiate between normal and asynchronous function definitions), but pyan does at least not crash anymore when the code contains `async def`.